### PR TITLE
longhorn recipe

### DIFF
--- a/recipes/ingress-nginx.yaml
+++ b/recipes/ingress-nginx.yaml
@@ -19,3 +19,6 @@ app:
     type: helm
   namespace: ingress-nginx
   version: 3.34.0
+  post_cleanup:
+    steps:
+      - kubectl delete namespace ingress-nginx

--- a/recipes/ingress-nginx.yaml
+++ b/recipes/ingress-nginx.yaml
@@ -1,3 +1,9 @@
+# ingress-nginx
+# Description: Detects Kubernetes provider type and install ingress-nginx controller
+# Tested on:
+# - EKS eks.5
+# - GKE 1.19.9-gke.1900
+# - Digital Ocean 1.21.2-do.2
 apiVersion: v1
 kind: kbrew
 app:

--- a/recipes/ingress-nginx.yaml
+++ b/recipes/ingress-nginx.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: kbrew
+app:
+  args:
+    # annotation for EKS
+    controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type": '{{ $providerID := (index (lookup "v1" "Node" "" "").items 0).spec.providerID }}{{ if hasPrefix "aws" $providerID }}nlb{{end}}'
+    # annotations for Digital Ocean
+    controller.service.annotations."service\.beta\.kubernetes\.io/do-loadbalancer-enable-proxy-protocol": '{{ $providerID := (index (lookup "v1" "Node" "" "").items 0).spec.providerID }}{{ if hasPrefix "digitalocean" $providerID }}true{{end}}'
+    controller.config."use-proxy-protocol": '{{ $providerID := (index (lookup "v1" "Node" "" "").items 0).spec.providerID }}{{ if hasPrefix "digitalocean" $providerID }}true{{end}}'
+  repository:
+    name: ingress-nginx
+    url: https://kubernetes.github.io/ingress-nginx
+    type: helm
+  namespace: ingress-nginx
+  version: 3.34.0

--- a/recipes/longhorn.yaml
+++ b/recipes/longhorn.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: kbrew
+app:
+  repository:
+    name: longhorn
+    url: https://charts.longhorn.io
+    type: helm
+  namespace: "longhorn-system"
+  pre_install:
+  - steps:
+    - curl -s https://raw.githubusercontent.com/longhorn/longhorn/v1.1.1/scripts/environment_check.sh | bash
+  post_install:
+  - steps:
+    - echo ${USER}:$(echo ${PASSWORD} | openssl passwd -stdin -apr1) >> auth
+    - kubectl -n longhorn-system create secret generic basic-auth --from-file=auth
+    - |
+      echo "
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: longhorn-ingress
+        namespace: longhorn-system
+        annotations:
+          # type of authentication
+          nginx.ingress.kubernetes.io/auth-type: basic
+          # prevent the controller from redirecting (308) to HTTPS
+          nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+          # name of the secret that contains the user/password definitions
+          nginx.ingress.kubernetes.io/auth-secret: basic-auth
+          # message to display with an appropriate context why the authentication is required
+          nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required '
+      spec:
+        rules:
+        - http:
+            paths:
+            - path: /
+              backend:
+                serviceName: longhorn-frontend
+                servicePort: 80
+      " | kubectl -n longhorn-system create -f -

--- a/recipes/longhorn.yaml
+++ b/recipes/longhorn.yaml
@@ -24,8 +24,7 @@ app:
   - apps:
     - ingress-nginx
   - steps:
-    - echo ${USERNAME}:$(echo ${PASSWORD} | openssl passwd -stdin -apr1) >> /tmp/auth
-    - kubectl -n longhorn-system create secret generic basic-auth --from-file=/tmp/auth
+    - kubectl -n longhorn-system create secret generic basic-auth --from-literal=auth=$(echo ${USERNAME}:$(echo ${PASSWORD} | openssl passwd -stdin -apr1))
     - |
       echo "
       apiVersion: networking.k8s.io/v1
@@ -66,4 +65,4 @@ app:
       - kubectl delete secret basic-auth -n longhorn-system
       - kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn-manager/master/deploy/prerequisite/longhorn-iscsi-installation.yaml
       - kubectl delete ingress longhorn-ingress -n longhorn-system
-      - kubectl delete ns longhorn-system ingress-nginx
+      - kubectl delete ns longhorn-system

--- a/recipes/longhorn.yaml
+++ b/recipes/longhorn.yaml
@@ -1,3 +1,9 @@
+# Longhorn recipe
+# Description: Installs iscsi daemonset, longhorn and ingress-nginx
+# Tested on:
+# - EKS eks.5
+# - GKE 1.19.9-gke.1900
+# - Digital Ocean 1.21.2-do.2
 apiVersion: v1
 kind: kbrew
 app:
@@ -18,8 +24,8 @@ app:
   - apps:
     - ingress-nginx
   - steps:
-    - echo ${USERNAME}:$(echo ${PASSWORD} | openssl passwd -stdin -apr1) >> auth
-    - kubectl -n longhorn-system create secret generic basic-auth --from-file=auth
+    - echo ${USERNAME}:$(echo ${PASSWORD} | openssl passwd -stdin -apr1) >> /tmp/auth
+    - kubectl -n longhorn-system create secret generic basic-auth --from-file=/tmp/auth
     - |
       echo "
       apiVersion: networking.k8s.io/v1
@@ -48,6 +54,13 @@ app:
                   port:
                     number: 80
       " | kubectl -n longhorn-system create -f -
+    # post installation checks
+    - kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/simple_pvc.yaml
+    - kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/simple_pod.yaml
+  pre_cleanup:
+    steps:
+      - kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/simple_pod.yaml
+      - kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/simple_pvc.yaml
   post_cleanup:
     steps:
       - kubectl delete secret basic-auth -n longhorn-system

--- a/recipes/longhorn.yaml
+++ b/recipes/longhorn.yaml
@@ -8,11 +8,17 @@ app:
   namespace: "longhorn-system"
   pre_install:
   - steps:
+    - openssl version
+      # Recipe needs USER and PASSWORD environment variables for ingress basic auth
+    - ': "${USERNAME:?Variable USERNAME not set or empty}" : "${PASSWORD:?Variable PASSWORD not set or empty}"'
     - curl -s https://raw.githubusercontent.com/longhorn/longhorn/v1.1.1/scripts/environment_check.sh | bash
+      # daemonset for iscsi service installation
     - kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn-manager/master/deploy/prerequisite/longhorn-iscsi-installation.yaml
   post_install:
+  - apps:
+    - ingress-nginx
   - steps:
-    - echo ${USER}:$(echo ${PASSWORD} | openssl passwd -stdin -apr1) >> auth
+    - echo ${USERNAME}:$(echo ${PASSWORD} | openssl passwd -stdin -apr1) >> auth
     - kubectl -n longhorn-system create secret generic basic-auth --from-file=auth
     - |
       echo "
@@ -42,3 +48,9 @@ app:
                   port:
                     number: 80
       " | kubectl -n longhorn-system create -f -
+  post_cleanup:
+    steps:
+      - kubectl delete secret basic-auth -n longhorn-system
+      - kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn-manager/master/deploy/prerequisite/longhorn-iscsi-installation.yaml
+      - kubectl delete ingress longhorn-ingress -n longhorn-system
+      - kubectl delete ns longhorn-system ingress-nginx

--- a/recipes/longhorn.yaml
+++ b/recipes/longhorn.yaml
@@ -9,6 +9,7 @@ app:
   pre_install:
   - steps:
     - curl -s https://raw.githubusercontent.com/longhorn/longhorn/v1.1.1/scripts/environment_check.sh | bash
+    - kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn-manager/master/deploy/prerequisite/longhorn-iscsi-installation.yaml
   post_install:
   - steps:
     - echo ${USER}:$(echo ${PASSWORD} | openssl passwd -stdin -apr1) >> auth

--- a/recipes/longhorn.yaml
+++ b/recipes/longhorn.yaml
@@ -34,7 +34,10 @@ app:
         - http:
             paths:
             - path: /
+              pathType: Prefix
               backend:
-                serviceName: longhorn-frontend
-                servicePort: 80
+                service:
+                  name: longhorn-frontend
+                  port:
+                    number: 80
       " | kubectl -n longhorn-system create -f -


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

Recipe to install `longhorn` and  `ingress-nginx` as the ingress controller

As a prerequisites, the recipe runs a script to check the cluster for potential issues to Longhorn and also installs a daemonset to install iscsid service on nodes.
Creates a secret and an Ingress resource for the users to access the UI
The secret creation expects environment variables `USER` and `PASSWORD` to be set

