### PR TITLE
Add recipe for minio-operator and minio-tenant

### DIFF
--- a/recipes/minio-operator.yaml
+++ b/recipes/minio-operator.yaml
@@ -1,0 +1,25 @@
+# https://github.com/minio/operator/tree/master/helm/minio-operator
+apiVersion: v1
+kind: kbrew
+app:
+  pre_install:
+  - steps:
+    - |
+      # Prerequisites
+      # https://github.com/minio/operator#prerequisites
+      minK8sVersion="v1.19.0"
+      expected=$(echo $minK8sVersion |  sed 's/v//g' | sed 's/\.//g')
+      k8sVersion=$(kubectl version --short=true --output json | jq -r ".serverVersion.gitVersion" | sed 's/-.*//g' | sed 's/v//g' | sed 's/\.//g')
+      if [ $expected -gt $k8sVersion ]
+      then
+        echo "The cluster does not meet requirements."
+        echo "Kubernetes version v1.19.0 or later required."
+        exit 1
+      fi
+  repository:
+    name: minio-operator
+    url: https://operator.min.io
+    type: helm
+  namespace: "minio-operator"
+  sha256:
+  version: 4.1.0

--- a/recipes/minio-tenant.yaml
+++ b/recipes/minio-tenant.yaml
@@ -1,0 +1,54 @@
+# MinIO tenant
+# Description: minio-tenant creates MinIO operator and a minio tenant
+# https://github.com/minio/operator/tree/master/helm/minio-operator
+apiVersion: v1
+kind: kbrew
+app:
+  pre_install:
+  - steps:
+    - |
+      # Prerequisites - The StorageClass must have volumeBindingMode: WaitForFirstConsumer
+      # https://github.com/minio/operator#prerequisites
+      scList=$(kubectl get storageclass -o jsonpath='{.items[?(@.volumeBindingMode=="WaitForFirstConsumer")].metadata.name}')
+      if [ -z "$scList" ]
+      then
+        echo "The cluster does not meet requirements."
+        echo "Atleast 1 StorageClass should have WaitForFirstConsumer volumeBindingMode."
+        exit 1
+      fi
+  - apps:
+    - minio-operator
+  # TODO: Remove once https://github.com/kbrew-dev/kbrew/issues/80 is addressed
+  - steps:
+    - kubectl create namespace minio-tenant
+  repository:
+    name: minio
+    url: https://raw.githubusercontent.com/minio/operator/v4.1.0/examples/tenant-lite.yaml
+    type: raw
+  args:
+    Tenant.minio.spec.pools[0].volumeClaimTemplate.spec.storageClassName: '{{ $storageClass := "default" }}{{ range $index, $sc := (lookup "storage.k8s.io/v1" "StorageClass" "" "").items }}{{ if eq $sc.volumeBindingMode "WaitForFirstConsumer"}}{{ $storageClass = $sc.metadata.name }}{{ end }}{{ end }}{{ $storageClass }}'
+    Tenant.minio.spec.pools[0].volumeClaimTemplate.spec.resources.requests.storage: 10Gi
+  namespace: "minio-tenant"
+  sha256:
+  version: 4.1.0
+  post_install:
+  - steps:
+    - |
+      # Wait for tenant to be ready
+      echo "Waiting for tenant to be ready"
+      retry=0
+      while true;
+      do
+        currentState=$(kubectl get tenant -n minio-tenant minio -o jsonpath='{.status.currentState}')
+        if [ ! -z "${currentState}" ] && [ "${currentState}" = "Initialized" ]; then break; fi
+        if [ "${retry}" = 60 ]; then echo "timed out while waiting for minio tenant to be ready"; exit 1; fi
+        sleep 10
+        retry=$((retry+1))
+      done
+    - |
+      # Print console info
+      echo "NOTE:"
+      echo "Port forward with following command to access minio-tenant console - 'kubectl port-forward svc/minio-console -n minio-tenant 9443:9443'"
+      echo "Console ACCESS_KEY: $(kubectl get secret -n minio-tenant console-secret -o jsonpath='{.data.CONSOLE_ACCESS_KEY}' | base64 -d)"
+      echo "Console SECRET_KEY: $(kubectl get secret -n minio-tenant console-secret -o jsonpath='{.data.CONSOLE_SECRET_KEY}' | base64 -d)"
+


### PR DESCRIPTION
Usage:
```
$ kbrew install minio-tenant
WARNING: version difference between client (1.21) and server (1.19) exceeds the supported minor version skew of +/-1
Installing helm app minio-operator/minio-operator
NAME: minio-operator
LAST DEPLOYED: Wed Jun  2 21:52:00 2021
NAMESPACE: minio-operator
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Get the JWT for logging in to the console:
  kubectl get secret $(kubectl get serviceaccount console-sa --namespace minio-operator -o jsonpath="{.secrets[0].name}") --namespace minio-operator -o jsonpath="{.data.token}" | base64 --decode 
2. Get the Operator Console URL by running these commands:
  kubectl --namespace minio-operator port-forward svc/console 9090:9090
  echo "Visit the Operator Console at http://127.0.0.1:9090"

namespace/minio-tenant created
Installing raw app minio/minio-tenant
secret/minio-creds-secret created
secret/console-secret created
tenant.minio.min.io/minio created
Waiting for components to be ready for minio-tenant
Waiting for tenant to be ready
NOTE:
Port forward with following command to access minio-tenant console - 'kubectl port-forward svc/minio-console -n minio-tenant 9443:9443'
Console ACCESS_KEY: YOURCONSOLEACCESS
Console SECRET_KEY: YOURCONSOLESECRET
```